### PR TITLE
Auto-configure connections to services referenced by sparqlGraphWeb

### DIFF
--- a/.env
+++ b/.env
@@ -7,7 +7,7 @@ hostip
 
 # Proxy settings [optional] - set if your network requires a proxy to connect to the Internet
 export httpProxyHost=
-export httpProxyPort=8080
+export httpProxyPort=80
 if [ -z "${httpProxyHost}" ]; then
 	export http_proxy=""
 else
@@ -192,6 +192,14 @@ export ingestionApplicationName=IngestionService
 export PORT_SPARQLGRAPH_WEB=8860
 export INGEST_URL=http://${HOST_IP}:12091/ingestion/
 export QUERY_URL=http://${HOST_IP}:12050/sparqlQueryService/
+export STATUS_URL=http://${HOST_IP}:12051/status/
+export RESULTS_URL=http://${HOST_IP}:12052/results/
+export DISPATCHER_URL=http://${HOST_IP}:12053/dispatcher/
+export HIVE_URL=http://${HOST_IP}:12055/hiveService/
+export NGSTORE_URL=http://${HOST_IP}:12056/nodeGroupStore/
+export OINFO_URL=http://${HOST_IP}:12057/ontologyinfo/
+export NGEXEC_URL=http://${HOST_IP}:12058/nodeGroupExecution/
+export NG_URL=http://${HOST_IP}:12059/nodeGroup/
 
 ## semtk-utility service
 # placeholder for when this service is created

--- a/compose.yml
+++ b/compose.yml
@@ -279,6 +279,15 @@ services:
     environment:
       - INGEST_URL
       - QUERY_URL
+      - STATUS_URL
+      - RESULTS_URL
+      - DISPATCHER_URL
+      - HIVE_URL
+      - NGSTORE_URL
+      - OINFO_URL
+      - NGEXEC_URL
+      - NG_URL
+      - triplestoreServerAndPort
     ports:
       - ${PORT_SPARQLGRAPH_WEB}:8080
     networks:

--- a/sparqlGraphWeb/entrypoint.sh
+++ b/sparqlGraphWeb/entrypoint.sh
@@ -9,9 +9,28 @@ echo ""
 echo "Configuring sparqlGraph UI ..."
 INGEST_SEARCH=http://localhost:12091/ingestion/
 QUERY_SEARCH=http://localhost:12050/sparqlQueryService/
+STATUS_SEARCH=http://localhost:12051/status/
+RESULTS_SEARCH=http://localhost:12052/results/
+DISPATCHER_SEARCH=http://localhost:12053/dispatcher/
+HIVE_SEARCH=http://localhost:12055/hiveService/
+NGSTORE_SEARCH=http://localhost:12056/nodeGroupStore/
+OINFO_SEARCH=http://localhost:12057/ontologyinfo/
+NGEXEC_SEARCH=http://localhost:12058/nodeGroupExecution/
+NG_SEARCH=http://localhost:12059/nodeGroup/
+CONNECTION_SEARCH=http://localhost:2420
 FILE_PATH=/usr/local/tomcat/webapps/sparqlGraph/main-oss/sparqlgraphconfigOss.js
+FILE2_PATH=/usr/local/tomcat/webapps/sparqlGraph/main-oss/demoNodegroup.json
 sed --in-place "s#${INGEST_SEARCH}#${INGEST_URL}#g" "${FILE_PATH}"
 sed --in-place "s#${QUERY_SEARCH}#${QUERY_URL}#g" "${FILE_PATH}"
+sed --in-place "s#${STATUS_SEARCH}#${STATUS_URL}#g" "${FILE_PATH}"
+sed --in-place "s#${RESULTS_SEARCH}#${RESULTS_URL}#g" "${FILE_PATH}"
+sed --in-place "s#${DISPATCHER_SEARCH}#${DISPATCHER_URL}#g" "${FILE_PATH}"
+sed --in-place "s#${HIVE_SEARCH}#${HIVE_URL}#g" "${FILE_PATH}"
+sed --in-place "s#${NGSTORE_SEARCH}#${NGSTORE_URL}#g" "${FILE_PATH}"
+sed --in-place "s#${OINFO_SEARCH}#${OINFO_URL}#g" "${FILE_PATH}"
+sed --in-place "s#${NGEXEC_SEARCH}#${NGEXEC_URL}#g" "${FILE_PATH}"
+sed --in-place "s#${NG_SEARCH}#${NG_URL}#g" "${FILE_PATH}"
+sed --in-place "s#${CONNECTION_SEARCH}#${triplestoreServerAndPort}#g" "${FILE2_PATH}"
 cat /usr/local/tomcat/webapps/sparqlGraph/main-oss/sparqlgraphconfigOss.js
 
 # Start tomcat


### PR DESCRIPTION
This change uses environment variable substitution using sed to modify the configuration files of sparqlGraphWeb at startup time.