### PR TITLE
Initial build and release workflows with Github Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,22 @@
+name: Build
+on: [push]
+
+jobs:
+  build:
+    name: Build SemTK
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cache Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: maven-${{ hashFiles('**/pom.xml') }}
+
+      - shell: bash
+        name: Build SemTK
+        run: |
+          # TODO: The tests currently fail in Github Actions.
+          mvn --batch-mode clean install -DskipTests
+

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,51 @@
+name: Release
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  build:
+    name: Build and release SemTK
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cache Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: maven-${{ hashFiles('**/pom.xml') }}
+
+      - shell: bash
+        name: Build SemTK
+        run: |
+          # TODO: The tests currently fail in Github Actions.
+          mvn --batch-mode clean install -DskipTests
+
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: true
+          prerelease: false
+
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+
+      - name: Upload release assets
+        id: upload_release_asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: "distribution/target/semtk-opensource-${{ steps.get_version.outputs.VERSION }}-bin.tar.gz"
+          asset_name: semtk-opensource-${{ steps.get_version.outputs.VERSION }}-bin.tar.gz
+          asset_content_type: application/gzip
+


### PR DESCRIPTION
These are some relatively minimal build and release workflows for SemTK. Some things to note:

 1. There's some duplicated work between the build and release workflows (they both build SemTK). Since releases are relatively infrequent, I don't think this is a huge issue.
 2. The tests are skipped. I tried enabling them, but they failed. I think it's fine to start with a build and try to debug the tests if SemTK developers find it worthwhile.

You can see examples of these workflows in action on my fork (after I pushed a fake `v0.0.1` tag):
- https://github.com/langston-barrett/semtk/releases
- https://github.com/langston-barrett/semtk/tags
- https://github.com/langston-barrett/semtk/actions